### PR TITLE
Releaseコマンドの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground",
     "lint": "eslint .",
     "prepack": "nuxt-module-build",
-    "release": "yarn lint && yarn prepack && npm publish"
+    "release": "nuxi prepare playground && yarn lint && yarn prepack && npm publish"
   },
   "dependencies": {
     "@nuxt/kit": "^3.2.0",


### PR DESCRIPTION
`yarn release` に `nuxi prepare playground` を追加しました！
リリースの際にplayground内のtsconfig.jsonが参照できないため、その前に生成を挟んでいます。