### PR TITLE
playgroundのenvにデフォルト値を設定

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,8 +3,8 @@ export default defineNuxtConfig({
     [
       '../src/module',
       {
-        serviceDomain: process.env.MICROCMS_SERVICE_DOMAIN,
-        apiKey: process.env.MICROCMS_API_KEY,
+        serviceDomain: process.env.MICROCMS_SERVICE_DOMAIN ?? 'servicedomain',
+        apiKey: process.env.MICROCMS_API_KEY ?? 'apikey',
       },
     ],
   ],


### PR DESCRIPTION
こちらもお願いします💦

GitHub Actoins で env が設定されていないケースを考慮していませんでした。
ここではmicroCMSからの値が取得できる必要はないため、仮の値を入れています。