### PR TITLE
fix(gh): Github WorkflowのNodeバージョン更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '22.x'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - name: release on npm


### PR DESCRIPTION
Nodeのバージョンが古いためpublishワークフローの実行に失敗し、npmへのパッケージのpublishに失敗しています。

このPRでは使用するNodeをv22（現在のLTS）に変更することでこれを解決します。